### PR TITLE
Fixed the typos in example code comments

### DIFF
--- a/examples/fibonacci/fibonacci.runk
+++ b/examples/fibonacci/fibonacci.runk
@@ -4,7 +4,7 @@
 (line "World's first runk powered Fibonacci generator!")
 
 # This section will repeat until the user enters a valid number
-!input                                              # "Input" lable
+!input                                              # "Input" label
 "Calculate until: "
 Nat max: (nat (in)) else !input                     # Reads a number from stdin, if input is not a number, then it jumps to !input again
 
@@ -13,10 +13,10 @@ Int n2: 0
 Int helper: 0
 Nat order: 1
 
-!loop                                               # A lable to return to at the beginning of every iteration.
+!loop                                               # A label to return to at the beginning of every iteration.
 (line $order "th: " $n2)                            # Prints previous number.
-helper: $n1                                         # Saving current number to herlper
+helper: $n1                                         # Saving current number to helper
 n1: (+ $n1 $n2)                                     # Sets current number to: current number + previous number
-n2: $helper                                         # Copyies helper into previous number
+n2: $helper                                         # Copies helper into previous number
 order: (+ $order 1)                                 # Increment order.
 (goif (<= $order $max) !loop)                       # Jumps if condition is not equal to zero.

--- a/examples/test.runk
+++ b/examples/test.runk
@@ -57,11 +57,11 @@ Int helper: 0
 Nat order: 1
 
 Lab lable: !loop
-!loop                                               # A lable to return to at the beginning of every iteration.
+!loop                                               # A label to return to at the beginning of every iteration.
 (line $order "th Fibonacci number is: " $n2 "!")    # Prints previous number.
-helper: $n1                                         # Saving current number to herlper
+helper: $n1                                         # Saving current number to helper
 n1: (+ $n1 $n2)                                     # Sets current number to: current number + previous number
-n2: $helper                                         # Copyies helper into previous number
+n2: $helper                                         # Copies helper into previous number
 order: (+ $order 1)                                 # Increment order.
 (goif (<= $order $max) $lable)                      # Jumps if condition is not equal to zero. 
 


### PR DESCRIPTION
There are some more in the actual code, but I'm not touching that.